### PR TITLE
Solve missing/assumed install instructions #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ We'll bootstrap everything, including installation of ArgoCD, from this public r
 At the end of this guide, you'll have Flux running alongside ArgoCD locally on your KIND cluster. You'll run FSA in the anonymous mode, and see 2 pre-defined ArgoCD Applications, each of which points to its equivalent Flux Kustomization.
 
 Install CLIs
+- [kind cli](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) 
+- [Flux cli](https://fluxcd.io/docs/cmd/)
+- [ArgoCD cli](https://argo-cd.readthedocs.io/en/stable/cli_installation/)
+
+Example install in macOS via [homebrew](https://brew.sh/)
+
 ```shell
 # install KIND cli
 brew install kind
@@ -42,6 +48,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 30s
+  # Change url to your forked gitrepo e.g, https://github.com/GitHubUserID/flamingo
   url: https://github.com/chanwit/flamingo
   ref:
     branch: main


### PR DESCRIPTION
my simple contribution from my test in machine without flux, and argocd, probably need to point out that argocd should be already running before the bootstrap of the application